### PR TITLE
add required keys to lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,3 +12,5 @@ jobs:
       - uses: stoplightio/spectral-action@v0.7.0
         with:
           file_glob: "./Lob-API-public.yml"
+          repo_token: ${{ github.token }}
+          event_name: ${{ github.event_name }}


### PR DESCRIPTION
While the workflow works without them, the linter flags them as missing.