### PR TITLE
add 'make bundle' command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 TODO.txt
+dist/*-bundled.yml

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+
+SPEC_FILE ?= Lob-API-public
+
+.PHONY: bundle
+bundle:
+	npx @redocly/openapi-cli bundle -o dist/$(SPEC_FILE)-bundled.yml $(SPEC_FILE).yml

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ Working in this repo until we get the first endpoint or two in place.
 
 ## What's here and how to work with it
 
-
-* I found a Redoc preview VS Code extension! It also provides linting that 
+* I found a Redoc preview VS Code extension! It also provides linting that
   complements Spectral. Please install `42crunch.vscode-openapi` and uninstall
   any of the previous preview extensions you may have had installed. To preview
   the docs (and a great way to QA PRs), open `Lob-API-public.yml` and click on
@@ -14,9 +13,11 @@ Working in this repo until we get the first endpoint or two in place.
 * If you have the stoplight spectral extension installed (v0.2.4), it will run
   as you type. I find it useful to install it as a CLI as well, as the VS Code
   plugin can get confused.
-  
-* I am finding that the linting by vscode-openapi catches some things that 
-  Spectral misses and vice-versa. 
+
+* I am finding that the linting by vscode-openapi catches some things that
+  Spectral misses and vice-versa.
+
+* To produce a single file version of the spec in the traditional layout, run `make bundle`
 
 ## See Also
 


### PR DESCRIPTION
Provides the ability to bundle the spec into a single file with a layout that works with most OpenAPI tooling. https://lobsters.atlassian.net/browse/HAS-31

