### PR TITLE
Spectral cleanup

### DIFF
--- a/.spectral.yml
+++ b/.spectral.yml
@@ -1,7 +1,6 @@
 extends: spectral:oas
 rules:
   operation-default-response: off
-  operation-singular-tag: off
 
   path-item-must-be-ref:
     description: Path Item Object value must be a $ref

--- a/.spectral.yml
+++ b/.spectral.yml
@@ -1,4 +1,4 @@
-extends: spectral:oas
+extends: [[spectral:oas, all]]
 rules:
   operation-default-response: off
 

--- a/resources/addresses/address.yml
+++ b/resources/addresses/address.yml
@@ -13,6 +13,7 @@ get:
   parameters:
     - in: path
       name: id
+      description: id of the address to retrieve
       required: true
       schema:
         $ref: 'attributes/adr_id.yml#/id'


### PR DESCRIPTION
A tiny PR with some Spectral improvements that arose as a side-effect of some debugging I'm doing.

* I removed a rule `operation-singular-tag: off` because it is no longer needed; `operation-singular-tag` is now set to `off` by default.
* I enabled the full Spectral OAS v3 ruleset (`extends: [[spectral:oas, all]]`). Using `extends: spectral:oas`, which is what we had before, enables a subset of the Spectral OAS v3 ruleset.