### PR TITLE
add error responses

### DIFF
--- a/.spectral.yml
+++ b/.spectral.yml
@@ -1,6 +1,5 @@
 extends: [[spectral:oas, all]]
 rules:
-  operation-default-response: off
 
   path-item-must-be-ref:
     description: Path Item Object value must be a $ref

--- a/resources/addresses/address.yml
+++ b/resources/addresses/address.yml
@@ -21,3 +21,6 @@ get:
   responses:
     '200':
       $ref: responses/address.yml
+
+    default:
+      $ref: '../../shared/responses/error.yml'

--- a/resources/addresses/addresses.yml
+++ b/resources/addresses/addresses.yml
@@ -16,3 +16,6 @@ get:
   responses:
     '200':
       $ref: responses/all_addresses.yml
+
+    default:
+      $ref: '../../shared/responses/error.yml'

--- a/shared/attributes/failure_status_code.yml
+++ b/shared/attributes/failure_status_code.yml
@@ -1,0 +1,20 @@
+type: integer
+
+enum:
+  - 401
+  - 403
+  - 404
+  - 422
+  - 429
+  - 500
+
+description: >
+  A conventional HTTP status code:
+    * 401 - Authorization error with your API key or account
+    * 403 - Forbidden error with your API key or account
+    * 404 - The requested item does not exist
+    * 422 - The query or body parameters did not pass validation
+    * 429 - Too many requests have been sent with an API key in a given amount of time
+    * 500 - An internal server error occurred, please contact support@lob.com
+
+example: 429

--- a/shared/models/error.yml
+++ b/shared/models/error.yml
@@ -1,0 +1,19 @@
+type: object
+
+description: >-
+  Lob uses RESTful HTTP response codes to indicate success or failure of an
+  API request. In general, 2xx indicates success, 4xx indicate an input error,
+  and 5xx indicates an error on Lob's end.
+
+required:
+  - message
+  - status_code
+
+properties:
+  message:
+    type: string
+    description: A human-readable message with more details about the error
+    example: Rate limit exceeded. Please wait 5 seconds and try your request again.
+
+  status_code:
+    $ref: '../attributes/failure_status_code.yml'

--- a/shared/responses/error.yml
+++ b/shared/responses/error.yml
@@ -1,0 +1,6 @@
+description: Error
+
+content:
+  application/json:
+    schema:
+      $ref: '../models/error.yml'


### PR DESCRIPTION
This PR adds an [error model](https://lobsters.atlassian.net/browse/HAS-27) that is shared by all endpoints and uses that error model with the default response to model(*) the failure responses for the two existing endpoints (https://lobsters.atlassian.net/browse/HAS-8).

(*) See "Default Response" on https://swagger.io/docs/specification/describing-responses/