### PR TITLE
update spec to match reality

### DIFF
--- a/resources/addresses/models/address.yml
+++ b/resources/addresses/models/address.yml
@@ -112,7 +112,6 @@ properties:
     description: >
       Must be a 2 letter country short-name code (ISO 3166). Defaults to <code>US</code>.
     minLength: 2
-    maxLength: 2
     example: US
 
   recipient_moved:


### PR DESCRIPTION
While the documentation (and therefore the spec) specify a two letter
(ISO 3166) country code, the value returned for the example in the docs
does not conform. The discrepancy reveals that the field does not have
adequate restrictions on the backend. I removed the restriction on the
spec (although I did not change the wording) until we can fix the
backend.