### PR TITLE
add Prism instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Working in this repo until we get the first endpoint or two in place.
 
+- [hackathon-spec-v1](#hackathon-spec-v1)
+  - [How the spec is organized](#how-the-spec-is-organized)
+  - [Style Guide and Linting](#style-guide-and-linting)
+  - [Previewing the spec as docs (aka QAing your work)](#previewing-the-spec-as-docs-aka-qaing-your-work)
+  - [Local Contract Testing](#local-contract-testing)
+  - [Compatibility with Community Tooling](#compatibility-with-community-tooling)
+  - [See Also](#see-also)
 ## How the spec is organized
 
 Our spec is organized semantically, by *resource*, instead of syntactically, by OpenAPI element.
@@ -52,6 +59,66 @@ To preview the spec using redoc:
 * Drill down into the documentation to make sure that your examples are populating correctly.
 * Run the code samples to be sure they are correct.
 * Compare the response you get to the example response.
+
+## Local Contract Testing
+
+You can run [Prism](https://meta.stoplight.io/docs/prism/README.md) locally as a
+[validation proxy](https://meta.stoplight.io/docs/prism/docs/getting-started/03-cli.md#proxy) to do
+contract testing when working on your code or reviewing PRs. (We plan to setup Prism to run contract tests
+using a test key as part of CI via a github action. In the interim, here's a quick intro to using Prism
+locally.)
+
+You can run Prism in a variety of ways, including via Docker. The instructions given here are for a local
+install via npm. Once you have installed Prism, in a terminal, run
+
+```
+hilary-holz@brick:~/repos/hilary/hackathon-spec-v1$ prism proxy Lob-API-public.yml https://api.lob.com/v1
+[1:20:53 PM] › [CLI] …  awaiting  Starting Prism…
+[1:20:53 PM] › [CLI] ℹ  info      GET        http://127.0.0.1:4010/addresses/adr_D9V2vWn
+[1:20:53 PM] › [CLI] ℹ  info      GET        http://127.0.0.1:4010/addresses?Limit=55
+[1:20:53 PM] › [CLI] ▶  start     Prism is listening on http://127.0.0.1:4010
+```
+
+Once Prism is listening, you can issue http requests to the proxy port, in this case `http://127.0.0.1:4010` using
+the client of your choice. I like [httpie](https://httpie.io/docs#main-features), a user friendly client.
+
+```
+hilary-holz@brick:~/repos/hilary/hackathon-spec-v1$ http -a $LOB_API_SECRET_TEST: -v GET http://127.0.0.1:4010/addresses Accept-Encoding:
+GET /addresses HTTP/1.1
+Accept: */*
+Authorization: Basic dGVzdF85NWI4ZjZiY2E5YzZlMjI1MGY5OWE4NWNlMDRjMGJjZGExODo=
+Connection: keep-alive
+Host: 127.0.0.1:4010
+User-Agent: HTTPie/1.0.3
+
+
+
+HTTP/1.1 200 OK
+Access-Control-Allow-Credentials: true
+Access-Control-Allow-Headers: *
+Access-Control-Allow-Origin: *
+Access-Control-Expose-Headers: *
+Connection: keep-alive
+Content-Length: 73
+Keep-Alive: timeout=5
+accept-ranges: bytes
+cache-control: no-cache
+content-type: application/json; charset=utf-8
+date: Wed, 16 Dec 2020 21:54:33 GMT
+vary: origin,accept-encoding
+
+{
+    "count": 0,
+    "data": [],
+    "next_url": null,
+    "object": "list",
+    "previous_url": null
+}
+```
+
+The `Accept-Encoding:` header included in the request unsets the default header `Accept-Encoding: gzip, deflate`.
+
+Any contract violations will be returned in a `s1-violations` header, which will contain a JSON object with all violations found in the response. You can also use the `--errors` flag which will turn any request or response violation found into a [RFC7807](https://tools.ietf.org/html/rfc7807) machine readable error.
 
 ## Compatibility with Community Tooling
 


### PR DESCRIPTION
Adding instructions on using Prism for contract testing locally so others can use it in the interim (before we get it integrated into make commands and CI).