### PR TITLE
add create_address

### DIFF
--- a/resources/addresses/address.yml
+++ b/resources/addresses/address.yml
@@ -16,7 +16,7 @@ get:
       description: id of the address to retrieve
       required: true
       schema:
-        $ref: 'attributes/adr_id.yml#/id'
+        $ref: 'attributes/adr_id.yml'
 
   responses:
     '200':

--- a/resources/addresses/addresses.yml
+++ b/resources/addresses/addresses.yml
@@ -19,3 +19,36 @@ get:
 
     default:
       $ref: '../../shared/responses/error.yml'
+
+post:
+  operationId: create_address
+
+  summary: Creates a new address object
+
+  description: >-
+    Creates a new address given information
+
+  tags:
+    - Addresses
+
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: 'models/address.yml'
+
+      application/x-www-form-urlencoded:
+        schema:
+          $ref: 'models/address.yml'
+
+      multipart/form-data:
+        schema:
+          $ref: 'models/address.yml'
+
+  responses:
+    '200':
+      $ref: responses/address.yml
+
+    default:
+      $ref: '../../shared/responses/error.yml'

--- a/resources/addresses/attributes/adr_id.yml
+++ b/resources/addresses/attributes/adr_id.yml
@@ -1,5 +1,5 @@
-id:
-  type: string
-  description: Unique identifier prefixed with <code>adr_</code>.
-  pattern: '^adr_[a-zA-Z0-9]+$'
-  example: adr_fa85158b26c3eb7c
+type: string
+description: Unique identifier prefixed with <code>adr_</code>.
+readOnly: true
+pattern: '^adr_[a-zA-Z0-9]+$'
+example: adr_fa85158b26c3eb7c

--- a/resources/addresses/models/address.yml
+++ b/resources/addresses/models/address.yml
@@ -3,16 +3,14 @@ type: object
 required:
   - id
   - address_line1
-  - address_country
   - date_created
   - date_modified
   - deleted
-  - metadata
   - object
 
 properties:
   id:
-    $ref: '../attributes/adr_id.yml#/id'
+    $ref: '../attributes/adr_id.yml'
 
   description:
     type: string
@@ -114,6 +112,9 @@ properties:
     minLength: 2
     example: US
 
+  metadata:
+    $ref: '../../../shared/attributes/metadata.yml#/metadata'
+
   recipient_moved:
     type: boolean
     description: >
@@ -127,31 +128,14 @@ properties:
       non-deliverable US addresses, or for addresses created before the NCOA
       feature was added to your account.
     nullable: true
+    readOnly: true
     example: false
-
-  metadata:
-    type: object
-    description: Metadata
-    properties: {}
-
-  date_created:
-    type: string
-    format: date-time
-    description: A timestamp in ISO 8601 format of the date the address was created.
-    example: "2017-09-05T17:47:53.767Z"
-
-  date_modified:
-    type: string
-    format: date-time
-    description: A timestamp in ISO 8601 format of the date the address was last modified.
-    example: "2017-09-05T17:47:53.767Z"
 
   deleted:
-    type: boolean
-    description: Only returned if the address has been successfully deleted.
-    example: false
+    $ref: '../../../shared/attributes/deleted.yml#/deleted'
 
-  object:
-    type: string
-    description: Value is <code>address</code>.
-    example: address
+  date_created:
+    $ref: '../../../shared/attributes/timestamps.yml#/date_created'
+
+  date_modified:
+    $ref: '../../../shared/attributes/timestamps.yml#/date_modified'

--- a/shared/attributes/deleted.yml
+++ b/shared/attributes/deleted.yml
@@ -1,0 +1,5 @@
+deleted:
+  type: boolean
+  description: Only returned if the address has been successfully deleted.
+  readOnly: true
+  example: false

--- a/shared/attributes/metadata.yml
+++ b/shared/attributes/metadata.yml
@@ -1,0 +1,13 @@
+metadata:
+  type: object
+  description: When creating any Lob object, you can include a metadata object with up to 20 key-value pairs of custom data.
+  properties: {}
+  example:
+    type: object
+    properties:
+      customer_id:
+        type: string
+        example: '987654'
+      campaign:
+        type: string
+        example: 'NEWYORK2015'

--- a/shared/attributes/object.yml
+++ b/shared/attributes/object.yml
@@ -1,0 +1,5 @@
+object:
+  type: string
+  description: Value is <code>address</code>.
+  readOnly: true
+  example: address

--- a/shared/attributes/timestamps.yml
+++ b/shared/attributes/timestamps.yml
@@ -1,0 +1,13 @@
+date_created:
+  type: string
+  format: date-time
+  description: A timestamp in ISO 8601 format of the date the address was created.
+  readOnly: true
+  example: "2017-09-05T17:47:53.767Z"
+
+date_modified:
+  type: string
+  format: date-time
+  description: A timestamp in ISO 8601 format of the date the address was last modified.
+  readOnly: true
+  example: "2017-09-05T17:47:53.767Z"


### PR DESCRIPTION
Co-Authored-By: Aditi Ramaswamy <aramas@umich.edu>

https://lobsters.atlassian.net/browse/HAS-13

In the process of adding the `POST addresses` endpoint, we revised the coding of the address model. 
* moved some attributes to `shared` as they are also used by one or more of the PDLC resources
* used `ReadOnly` to mark attributes that are `required` in the response, but cannot are not present in the create request
* revised the list of `required` attributes for the address model. The initial list came from the scraped spec, something to watch for.

Note that, while it was possible to use the same schema for all permissible media types for the `requestBody`, there's no guarantee that we will always be able to do so.

References:
* https://docs.lob.com/#requests
* https://docs.lob.com/#addresses_create
* https://swagger.io/docs/specification/describing-request-body/
* https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#request-body-object
* https://github.com/lob/hackathon-spec-v1#local-contract-testing

Happy Reviewing!!