### PR TITLE
add DELETE address endpoint

### DIFF
--- a/resources/addresses/address.yml
+++ b/resources/addresses/address.yml
@@ -1,3 +1,11 @@
+parameters:
+  - in: path
+    name: id
+    description: id of the address
+    required: true
+    schema:
+      $ref: 'attributes/adr_id.yml'
+
 get:
   operationId: get_address
 
@@ -10,17 +18,28 @@ get:
   tags:
     - Addresses
 
-  parameters:
-    - in: path
-      name: id
-      description: id of the address to retrieve
-      required: true
-      schema:
-        $ref: 'attributes/adr_id.yml'
-
   responses:
     '200':
       $ref: responses/address.yml
+
+    default:
+      $ref: '../../shared/responses/error.yml'
+
+delete:
+  operationId: delete_address
+
+  summary: Deletes address with given id
+
+  description: >-
+    Deletes the details of an existing address. You need only supply
+    the unique customer identifier that was returned upon address creation.
+
+  tags:
+    - Addresses
+
+  responses:
+    '200':
+      $ref: '../../shared/responses/deleted.yml'
 
     default:
       $ref: '../../shared/responses/error.yml'

--- a/resources/addresses/models/address.yml
+++ b/resources/addresses/models/address.yml
@@ -135,7 +135,7 @@ properties:
     example: false
 
   deleted:
-    $ref: '../../../shared/attributes/deleted.yml#/deleted'
+    $ref: '../../../shared/attributes/deleted.yml'
 
   date_created:
     $ref: '../../../shared/attributes/timestamps.yml#/date_created'

--- a/shared/attributes/deleted.yml
+++ b/shared/attributes/deleted.yml
@@ -1,5 +1,4 @@
-deleted:
-  type: boolean
-  description: Only returned if the address has been successfully deleted.
-  readOnly: true
-  example: false
+type: boolean
+description: Only returned if the address has been successfully deleted.
+readOnly: true
+example: false

--- a/shared/responses/deleted.yml
+++ b/shared/responses/deleted.yml
@@ -1,0 +1,11 @@
+description: Returns true if the delete was successful
+
+content:
+  application/json:
+    schema:
+      type: object
+      properties:
+        id:
+          $ref: '../../resources/addresses/attributes/adr_id.yml'
+        deleted:
+          $ref: '../attributes/deleted.yml'


### PR DESCRIPTION
Co-Authored-By: Aditi Ramaswamy <aramas@umich.edu>

https://lobsters.atlassian.net/browse/HAS-11 (completing HAS-9)

In addition to reviewing the code, you can test it locally by running:

```
prism proxy --errors Lob-API-public.yml https://api.lob.com/v1
```

and in another terminal, running

`curl -X DELETE https://api.lob.com/v1/addresses/adr_43769b47aed248c2  -u test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc:`

References:

* https://docs.lob.com/#addresses_delete
* https://meta.stoplight.io/docs/prism/docs/guides/03-validation-proxy.md

Happy Reviewing!!